### PR TITLE
Fix compiler issues

### DIFF
--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -107,7 +107,7 @@ public class NetworkStatsHelper {
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
-        } catch (RemoteException e) {
+        } catch (Exception e) {
             return -1;
         }
         NetworkStats.Bucket bucket = new NetworkStats.Bucket();
@@ -131,7 +131,7 @@ public class NetworkStatsHelper {
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                 packageUid);
-        } catch (RemoteException e) {
+        } catch (Exception e) {
             return -1;
         }
         NetworkStats.Bucket bucket = new NetworkStats.Bucket();
@@ -154,7 +154,7 @@ public class NetworkStatsHelper {
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                     packageUid);
-        } catch (RemoteException e) {
+        } catch (Exception e) {
             return -1;
         }
         NetworkStats.Bucket bucket = new NetworkStats.Bucket();
@@ -177,7 +177,7 @@ public class NetworkStatsHelper {
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
-        } catch (RemoteException e) {
+        } catch (Exception e) {
             return -1;
         }
         NetworkStats.Bucket bucket = new NetworkStats.Bucket();


### PR DESCRIPTION
This PR fixes a compiler exception where `RemoteException` is never thrown in body of try block.  This replaces it with the generic `Exception` as the error is never directly used in the `catch` block regardless.

This is in relation to creating an Android test build with Detox.  See [here](https://www.notion.so/birdie/Run-our-E2E-tests-on-Android-d078c1de3e224063ab00c74222353380#1fd0412afa2b4e0196e781a0dd2b5de9) for more details.

![image](https://user-images.githubusercontent.com/24386407/80807622-9d24d680-8bb5-11ea-9c65-b5cdc7ec8730.png)
